### PR TITLE
THREESCALE-11393: Upgrade the Dockefile for system image based on RHEL8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/3scale-amp2/system-rhel7:3scale2.14
+FROM registry.redhat.io/3scale-amp2/system-rhel8:3scale2.15
 
 USER root
 
@@ -7,14 +7,15 @@ COPY ./oracle-client-files/instantclient-basic*-linux.*.zip \
      ./oracle-client-files/instantclient-odbc-linux.*.zip \
      /opt/system/vendor/oracle/
 
-ENV LD_LIBRARY_PATH=/opt/oracle/instantclient/:$LD_LIBRARY_PATH \
+ENV LD_LIBRARY_PATH=/opt/oracle/instantclient/ \
     ORACLE_HOME=/opt/oracle/instantclient/ \
     DB=oracle \
     TZ=utc \
     NLS_LANG=AMERICAN_AMERICA.UTF8
 
-RUN ./script/oracle/install-instantclient-packages.sh \
- && source /opt/app-root/etc/scl_enable \
- && DB=oracle bundle install --local --deployment --jobs $(grep -c processor /proc/cpuinfo) --retry=5
+RUN dnf install wget unzip make ruby-devel gcc gcc-c++ redhat-rpm-config libaio -y \
+    && ./script/oracle/install-instantclient-packages.sh \
+    && ln -s /usr/lib64/libnsl.so.2 /usr/lib64/libnsl.so.1 \
+    && DB=oracle bundle install --jobs $(grep -c processor /proc/cpuinfo) --retry=5
 
 USER 1001

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 In order to work with Oracle Database for Red Hat 3scale API Management, you will need to create a custom image as Red Hat cannot distribute the binaries of Oracle Database client.
 
-You **MUST** download the client (basic-lite or basic), the odbc driver and the sdk for **19.6** in [Oracle Technology Network](https://www.oracle.com/technetwork/database/features/instant-client/index-097480.html).
+You must download the client (basic-lite or basic), the ODBC driver and the SDK with version **19.18** in [Oracle Instant Client Downloads for Linux x86-64 (64-bit)
+](https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html). If the files are not present in `oracle-client-files`, they will be downloaded during the build process.
 
 * Instant Client Package - Basic or Basic Lite
 * Instant Client Package - SDK
@@ -13,17 +14,16 @@ You **MUST** download the client (basic-lite or basic), the odbc driver and the 
 
 Example:
 
-    * instantclient-basiclite-linux.x64-19.6.0.0.0dbru.zip or instantclient-basic-linux.x64-19.6.0.0.0dbru.zip
-    * instantclient-sdk-linux.x64-19.6.0.0.0dbru.zip
-    * instantclient-odbc-linux.x64-19.6.0.0.0dbru.zip
+    * [instantclient-basiclite-linux.x64-19.18.0.0.0dbru.zip](https://download.oracle.com/otn_software/linux/instantclient/1918000/instantclient-basiclite-linux.x64-19.18.0.0.0dbru.zip) or [instantclient-basic-linux.x64-19.18.0.0.0dbru.zip](https://download.oracle.com/otn_software/linux/instantclient/1918000/instantclient-basic-linux.x64-19.18.0.0.0dbru.zip)
+    * [instantclient-sdk-linux.x64-19.18.0.0.0dbru.zip](https://download.oracle.com/otn_software/linux/instantclient/1918000/instantclient-sdk-linux.x64-19.18.0.0.0dbru.zip)
+    * [instantclient-odbc-linux.x64-19.18.0.0.0dbru.zip]( https://download.oracle.com/otn_software/linux/instantclient/1918000/instantclient-odbc-linux.x64-19.18.0.0.0dbru.zip)
 
 ## Instructions
 
 1 - Place the downloaded files in the `oracle-client-files` directory.
 
-
-2 -  Build the custom system Oracle-based image. The image tag must be a fixed image tag as in the following example:
+2 - Build the custom system Oracle-based image. The image tag must be a fixed image tag as in the following example:
 
 ```
-$ docker build . --tag myregistry.example.com/system-oracle:2.14.0-1
+$ podman build . --tag myregistry.example.com/system-oracle:2.15.0-1
 ```


### PR DESCRIPTION
Update the `Dockerfile` for building a system image with Oracle dependencies, based on the system image from 3scale 2.15.


https://issues.redhat.com/browse/THREESCALE-11393
