### PR TITLE
Bump base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/3scale-amp2/system-rhel9:3scale2.16.2
+FROM registry.redhat.io/3scale-amp2/system-rhel9:3scale2.16.3
 USER root
 
 COPY ./oracle-client-files/instantclient-basic*-linux.*.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/3scale-amp2/system-rhel9:3scale2.16.1
+FROM registry.redhat.io/3scale-amp2/system-rhel9:3scale2.16.2
 USER root
 
 COPY ./oracle-client-files/instantclient-basic*-linux.*.zip \


### PR DESCRIPTION
Bump the latest tag of the `registry.redhat.io/3scale-amp2/system-rhel9` image.